### PR TITLE
Modularization 2 - manage layer adding cache

### DIFF
--- a/isogeo.py
+++ b/isogeo.py
@@ -171,6 +171,7 @@ class Isogeo:
 
         # initialize plugin directory
         self.plugin_dir = os.path.dirname(__file__)
+        self.plg_basepath = os.path.dirname(os.path.realpath(__file__))
 
         # initialize locale
         locale = qsettings.value('locale/userLocale')[0:2]
@@ -216,13 +217,10 @@ class Isogeo:
         # submodules
         self.md_display = MetadataDisplayer(IsogeoMdDetails())
         self.results_mng = ResultsManager(self)
+        self.results_mng.cache_mng.loader()
 
         # link UI and submodules
         plg_api_mngr.ui_auth_form = self.auth_prompt_form
-        self.results_mng.paths_cache = os.path.realpath(os.path.join(plg_basepath,
-                                                                     "_user",
-                                                                     "paths_cache.json"))
-        self.results_mng._cache_loader()
 
         # start variables
         self.savedSearch = "first"
@@ -232,7 +230,7 @@ class Isogeo:
         self.showDetails = False
         self.store = False
         self.settingsRequest = False
-        self.PostGISdict = self.results_mng.layer_adder.build_postgis_dict(qsettings)
+        self.PostGISdict = self.results_mng.build_postgis_dict(qsettings)
 
         self.currentUrl = ""
         # self.currentUrl = "https://v1.api.isogeo.com/resources/search?
@@ -318,7 +316,7 @@ class Isogeo:
     def onClosePlugin(self):
         """Cleanup necessary items here when plugin dockwidget is closed."""
         # save cache
-        self.results_mng._cache_dumper()
+        self.results_mng.cache_mng.dumper()
         # disconnects
         self.dockwidget.closingPlugin.disconnect(self.onClosePlugin)
 
@@ -1457,7 +1455,7 @@ class Isogeo:
 
         # # -- Settings tab - Search --------------------------------------------
         # button to empty the cache of filepaths #135
-        self.dockwidget.btn_cache_trash.pressed.connect(self.results_mng._cache_cleaner)
+        self.dockwidget.btn_cache_trash.pressed.connect(self.results_mng.cache_mng.cleaner)
 
         # -- Settings tab - Application authentication ------------------------
         # Change user -> see below for authentication form

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,6 +1,6 @@
 from .api import IsogeoPlgApiMngr
 from .metadata_display import MetadataDisplayer
-from .results import ResultsManager
+from .results import ResultsManager, CacheManager 
 from .tools import IsogeoPlgTools
 from .quick_search import QuickSearchManager
-from .layer.add_layer import LayerAdder
+from .layer import LayerAdder

--- a/modules/layer/add_layer.py
+++ b/modules/layer/add_layer.py
@@ -88,62 +88,6 @@ class LayerAdder():
         self.tr = None
         self.md_sync = MetadataSynchronizer()
 
-    def build_postgis_dict(self, input_dict):
-        """Build the dict that stores informations about PostGIS connexions."""
-        # input_dict.beginGroup("PostgreSQL/connections")
-        final_dict = {}
-        for k in sorted(input_dict.allKeys()):
-            if k.startswith("PostgreSQL/connections/")\
-                    and k.endswith("/database"):
-                if len(k.split("/")) == 4:
-                    connection_name = k.split("/")[2]
-                    password_saved = input_dict.value(
-                        'PostgreSQL/connections/' +
-                        connection_name +
-                        '/savePassword')
-                    user_saved = input_dict.value(
-                        'PostgreSQL/connections/' +
-                        connection_name +
-                        '/saveUsername')
-                    if password_saved == 'true' and user_saved == 'true':
-                        dictionary = {'name':
-                                      input_dict.value(
-                                          'PostgreSQL/connections/' +
-                                          connection_name +
-                                          '/database'),
-                                      'host':
-                                      input_dict.value(
-                                          'PostgreSQL/connections/' +
-                                          connection_name +
-                                          '/host'),
-                                      'port':
-                                      input_dict.value(
-                                          'PostgreSQL/connections/' +
-                                          connection_name +
-                                          '/port'),
-                                      'username':
-                                      input_dict.value(
-                                          'PostgreSQL/connections/' +
-                                          connection_name +
-                                          '/username'),
-                                      'password':
-                                      input_dict.value(
-                                          'PostgreSQL/connections/' +
-                                          connection_name +
-                                          '/password')}
-                        final_dict[
-                            input_dict.value('PostgreSQL/connections/' +
-                                             connection_name +
-                                             '/database')
-                        ] = dictionary
-                    else:
-                        continue
-                else:
-                    pass
-            else:
-                pass
-        return final_dict
-
     def build_efs_url(self, api_layer, srv_details, rsc_type="ds_dyn_lyr_srv", mode="complete"):
         """Reformat the input Esri Feature Service url so it fits QGIS criterias.
 

--- a/modules/results/__init__.py
+++ b/modules/results/__init__.py
@@ -1,0 +1,2 @@
+from .display import ResultsManager
+from .cache import CacheManager

--- a/modules/results/cache.py
+++ b/modules/results/cache.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
+# Standard library
+import logging
+import json
+
+# ############################################################################
+# ########## Globals ###############
+# ##################################
+
+logger = logging.getLogger("IsogeoQgisPlugin")
+
+# ############################################################################
+# ########## Classes ###############
+# ##################################
+
+
+class CacheManager():
+    """Basic class to manage the cache system of the layer addition. 
+    """
+
+    def __init__(self, path_cache_file : str = None):
+        # Path to JSON cache file
+        if isinstance(path_cache_file, str):
+            self.cache_file = path_cache_file
+        elif path_cache_file != None:
+            raise TypeError("str expected")
+        else:
+            raise ValueError("path to JSON cache file must be given to instantiate CacheManager")
+
+        # Objects for storing inaccessible elements 
+        self.cached_dict = {}
+        self.cached_unreach_paths = []
+        self.cached_unreach_postgis = []
+        self.cached_unreach_srv = []
+
+    def dumper(self):
+        """Builds a dict from the stored inaccessible elements 
+        and dumps it into the JSON cache file.
+
+        :returns: the dict dumped in the JSON file
+
+        :rtype: dict
+        """
+        self.cached_dict = {"files" : list(set(self.cached_unreach_paths)),
+                            "PostGIS" : list(set(self.cached_unreach_postgis)),
+                            "services" : list(set(self.cached_unreach_srv))}
+        logger.debug("cached_dict : {}".format(self.cached_dict))
+
+        with open(self.cache_file, 'w') as cache:
+            json.dump([self.cached_dict], cache, indent=4)
+        logger.debug("Paths cache has been dumped")
+        
+        return self.cached_dict
+
+    def loader(self):
+        """Load and store ignored elements from the JSON cache file.
+        
+        :returns: the content of the JSON cache file
+
+        :rtype: dict
+        """
+        try:
+            with open(self.cache_file, 'r') as cache:
+                cache_loaded = json.load(cache)
+            logger.debug("cache_loaded : {}".format(cache_loaded))
+            if isinstance(cache_loaded[0], dict) :
+                self.cached_unreach_paths = cache_loaded[0].get("files")
+                self.cached_unreach_postgis = cache_loaded[0].get("PostGIS")
+                self.cached_unreach_srv = cache_loaded[0].get("services")
+                logger.debug("Paths cache has been loaded")
+            else:
+                logger.debug("Old cache file format detected")
+                self.cached_unreach_paths = cache_loaded
+            return cache_loaded
+
+        except ValueError as e:
+            logger.error("Path JSON corrupted")
+        except IOError:
+        	logger.debug("Paths cache file not found. Maybe because of first launch.")
+        	self.dumper()
+
+    def cleaner(self):
+        """Removes the stored elements and empties the JSON cache file."""
+        self.cached_unreach_paths = []
+        self.cached_unreach_postgis = []
+        self.cached_unreach_srv = []
+        self.dumper()
+        logger.debug("Cache has been cleaned")
+
+# #############################################################################
+# ##### Stand alone program ########
+# ##################################
+if __name__ == '__main__':
+    """Standalone execution."""

--- a/test/test_cache_manager.py
+++ b/test/test_cache_manager.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+# Standard library
+import unittest
+import json
+import os
+from pathlib import Path
+
+# Tested module
+from modules import CacheManager
+
+class TestCacheManager(unittest.TestCase):
+
+    def setUp(self):
+        self.cache_file = Path(__file__).parents[0] / "cache_test.json"
+        self.cache_mng = CacheManager(str(self.cache_file))
+     
+    def test_instantiation(self):
+        with self.assertRaises(TypeError):
+            CacheManager(1)
+        with self.assertRaises(ValueError):
+            CacheManager()
+        self.assertEqual(CacheManager("path").cache_file, "path")
+
+    def test_properties(self):
+        self.assertTrue(isinstance(self.cache_mng.cached_dict, dict))
+        self.assertTrue(isinstance(self.cache_mng.cached_unreach_paths, list))
+        self.assertTrue(isinstance(self.cache_mng.cached_unreach_postgis, list))
+        self.assertTrue(isinstance(self.cache_mng.cached_unreach_srv, list))
+
+    def test_dumper(self):
+        self.cache_mng.cached_unreach_paths = ["path1", "path2", "path1"]
+        self.cache_mng.cached_unreach_postgis = ["pg3", "pg4", "pg5", "pg3"]
+        self.cache_mng.cached_unreach_srv = ["srv6"]
+
+        self.assertTrue(isinstance(self.cache_mng.dumper(), dict))
+        self.assertEqual(self.cache_mng.dumper().get("services"), ["srv6"])
+
+    def test_loader(self):
+        self.assertTrue(isinstance(self.cache_mng.loader(), list))
+        self.assertTrue(isinstance(self.cache_mng.loader()[0], dict))
+
+        self.assertTrue(isinstance(self.cache_mng.cached_unreach_paths, list))
+        self.assertTrue(isinstance(self.cache_mng.cached_unreach_postgis, list))
+        self.assertTrue(isinstance(self.cache_mng.cached_unreach_srv, list))
+
+        self.assertEqual(sorted(self.cache_mng.cached_unreach_paths), sorted(["path1", "path2"]))
+        self.assertEqual(sorted(self.cache_mng.cached_unreach_postgis), sorted(["pg3", "pg4", "pg5"]))
+        self.assertEqual(self.cache_mng.cached_unreach_srv, ["srv6"])
+
+    def test_loader_old_files(self): 
+        with open(self.cache_mng.cache_file, 'w') as cache:
+            json.dump(["old/path"], cache, indent=4)
+
+        self.assertTrue(isinstance(self.cache_mng.loader(), list))
+        self.assertTrue(isinstance(self.cache_mng.loader()[0], str))
+        self.assertEqual(self.cache_mng.loader()[0], "old/path")
+        self.assertEqual(self.cache_mng.cached_unreach_paths, ["old/path"])
+
+    def test_cleaner(self):
+        self.cache_mng.cleaner()
+        
+        self.assertEqual(self.cache_mng.cached_unreach_paths, [])
+        self.assertEqual(self.cache_mng.cached_unreach_postgis, [])
+        self.assertEqual(self.cache_mng.cached_unreach_srv, [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# 2 new modules

## Context

Improve plugin operation and make corrections (#180 ).

## Achievments

### `modules/results/display.py`

* *Issue :* #179 

* **Commits :** [f25e18c](https://github.com/isogeo/isogeo-plugin-qgis/commit/f25e18cc5487f920db1ce379723708154fde2fde), [2e77b1d](https://github.com/isogeo/isogeo-plugin-qgis/commit/2e77b1d3864fcf2e4eaae5876e5281057c1eb693)

* **Class name :** **ResultsManager**

* **Purpose :** This class includes two methods of the old **ResultsManager** class (*show_results()* and *_filepath_builder()*) in addition to *build_postgis_dict()* method from the old **UrlBuilder** class. The result display works in much the same way as before. This `modules/results/display.py`  corresponds to what remains of the old `modules/results.py` after removing the cache management and adding the *build_postgis_dict()* method.

### `modules/results/cache.py`

* *Issue :* #179

* **Commits :** [f25e18c](https://github.com/isogeo/isogeo-plugin-qgis/commit/f25e18cc5487f920db1ce379723708154fde2fde), [2ce825e](https://github.com/isogeo/isogeo-plugin-qgis/commit/2ce825e18423cecb4de1c21596090234be127266)

* **Class name :** **CacheManager**

* **Purpose :** This class includes the 3 methods removed from the old `modules/results.py`: *_cache_dumper()*, *_cache_loader()* and *_cache_cleaner()* renamed *dumper()*, *loader()* and *cleaner()*. The management of the cache related to the addition of layer is now isolated in this `modules/results/cache.py`. It manages the storage of inaccessible elements detected during use, the writing of these elements in the JSON cache file, the recovery of these elements from the JSON cache file and the cleaning of this file. 

* **Improvement :** The old cache system only supported inaccessible file paths. This **CacheManager** has been developed to also store inaccessible services (OGC and ESRI) or databases. The structure of the JSON file has been modified to accommodate these 2 new types of elements while integrating the elements saved in the old cache format. It is therefore possible to manage the cache linked to all layer addition options but the detection of the elements to be cached will be developed later and will be managed in the `modules/results/display.py`.



