### PR TITLE
Modularization 4 - Displaying shares informations

### DIFF
--- a/isogeo.py
+++ b/isogeo.py
@@ -61,7 +61,6 @@ from . import resources
 # UI classes
 from .ui.isogeo_dockwidget import IsogeoDockWidget  # main widget
 from .ui.credits.dlg_credits import IsogeoCredits
-from .ui.metadata.dlg_md_details import IsogeoMdDetails
 from .ui.quicksearch.dlg_quicksearch_new import QuicksearchNew
 from .ui.quicksearch.dlg_quicksearch_rename import QuicksearchRename
 
@@ -207,7 +206,7 @@ class Isogeo:
 
         # SUBMODULES
         # instanciating
-        self.md_display = MetadataDisplayer(IsogeoMdDetails())
+        self.md_display = MetadataDisplayer()
 
         self.results_mng = ResultsManager(self)
         self.results_mng.cache_mng.loader()
@@ -229,7 +228,7 @@ class Isogeo:
         self.approps_mng.shares_ready.connect(self.write_shares_info) 
 
         # start variables
-        self.savedSearch = "first"
+        self.savedSearch = str
         self.loopCount = 0
         self.hardReset = False
         self.showResult = False
@@ -1258,6 +1257,7 @@ class Isogeo:
         self.dockwidget.cbb_chck_kw.setEnabled(plg_tools.test_qgis_style())  # see #137
         # self.dockwidget.cbb_chck_kw.setMaximumSize(QSize(250, 25))
         self.dockwidget.txt_input.setFocus()
+        self.savedSearch = "first"
         self.user_authentication()
 
 # #############################################################################

--- a/isogeo.py
+++ b/isogeo.py
@@ -72,6 +72,7 @@ from .modules import MetadataDisplayer
 from .modules import ResultsManager
 from .modules import IsogeoPlgTools
 from .modules import QuickSearchManager
+from .modules import SharesParser
 
 # ############################################################################
 # ########## Globals ###############
@@ -204,19 +205,28 @@ class Isogeo:
         self.quicksearch_rename_dialog = QuicksearchRename()
         self.credits_dialog = IsogeoCredits()
 
-        # submodules
+        # SUBMODULES
+        # instanciating
         self.md_display = MetadataDisplayer(IsogeoMdDetails())
 
         self.results_mng = ResultsManager(self)
         self.results_mng.cache_mng.loader()
 
+        self.approps_mng = SharesParser()
+        self.approps_mng.tr = self.tr
+
         self.authenticator = Authenticator(auth_folder=os.path.join(self.plg_basepath, "_auth"))
 
         self.api_requester = ApiRequester()
         self.api_requester.tr = self.tr
-        self.api_requester.token_received.connect(self.token_result)
+        
+        # connecting
+        self.api_requester.token_sig.connect(self.token_slot)
+        self.api_requester.search_sig.connect(self.update_fields)
+        self.api_requester.details_sig.connect(self.md_display.show_complete_md)
+        self.api_requester.shares_sig.connect(self.approps_mng.send_share_info)
 
-        # link UI and submodules
+        self.approps_mng.shares_ready.connect(self.write_shares_info) 
 
         # start variables
         self.savedSearch = "first"
@@ -225,11 +235,7 @@ class Isogeo:
         self.showResult = False
         self.showDetails = False
         self.store = False
-        self.settingsRequest = False
         self.PostGISdict = self.results_mng.build_postgis_dict(qsettings)
-
-        # self.api_requester.currentUrl = "https://v1.api.isogeo.com/resources/search?
-        # _limit=10&_include=links&_lang={0}".format(self.lang)
 
         self.old_text = ""
         self.page_index = 1
@@ -345,16 +351,12 @@ class Isogeo:
         their default value, it asks for them.
         If not, it tries to send a request.
         """
-        self.api_requester.status_isClear = False
         self.dockwidget.tab_search.setEnabled(False)
 
         api_init = self.authenticator.manage_api_initialization()
         if api_init[0]:
             self.dockwidget.tab_search.setEnabled(True)
-            self.api_requester.status_isClear = True
             self.api_requester.setup_api_params(api_init[1])
-            self.quicksearch.requester = self.api_requester
-
 
     def write_ids_and_test(self):
         """Store the id & secret and launch the test function.
@@ -366,15 +368,16 @@ class Isogeo:
         # launch authentication
         self.user_authentication()
     
-    def token_result(self, token_signal):
-        logger.debug(str(token_signal))
-        if token_signal == "tokenOk":
+    def token_slot(self, token_signal: str):
+        logger.debug(token_signal)
+        if token_signal == "tokenOK":
             if self.savedSearch == "first":
                 logger.debug("First search since plugin started.")
-                self.set_widget_status()
+                self.set_widget_status()  
+                logger.debug("Asking application properties to the Isogeo API.")
+                self.api_requester.send_request(request_type = "shares")     
             else:
-                self.api_requester.reply_ready.connect(self.update_fields)
-                self.api_requester.api_get_requests()
+                self.api_requester.send_request()
         elif token_signal == "credIssue":
             self.authenticator.display_auth_form()
             msgBar.pushMessage("Isogeo",
@@ -394,19 +397,16 @@ class Isogeo:
                                    level=1)
             self.pluginIsActive = False
 
-
-
     # -- UI - UPDATE SEARCH FORM ----------------------------------------------
-    def update_fields(self):
+    def update_fields(self, result: dict):
         """Update search form fields from search tags and previous search.
+        Slot connected to ApiRequster.search_sig (see modules/api/requester.py)
+        This takes an API answer ('result' parameter) and update the fields 
+        accordingly. It also calls show_results in the end. This may change,  
+        so results would be shown only when a specific button is pressed.
 
-        This takes an API answer and update the fields accordingly. It also
-        calls show_results in the end. This may change, so results would be
-        shown only when a specific button is pressed.
+        :param dict result: Parsed content of search request's reply
         """
-        result = self.api_requester.reply_content
-        self.api_requester.reply_ready.disconnect()
-        # logs
         logger.debug("Update_fields function called on the API reply. reset = "
                      "{}".format(self.hardReset))
         QgsMessageLog.logMessage("Query sent & received: {}"
@@ -829,7 +829,7 @@ class Isogeo:
         """Build the request url to be sent to Isogeo API.
 
         This builds the url, retrieving the parameters from the widgets. When
-        the final url is built, it calls api_get_requests
+        the final url is built, it calls get_request
         """
         logger.debug("Search function called. Building the "
                      "url that is to be sent to the API")
@@ -881,13 +881,7 @@ class Isogeo:
         self.api_requester.currentUrl = self.api_requester.build_request_url(params)
         logger.debug(self.api_requester.currentUrl)
         # Sending the request to Isogeo API
-        if self.api_requester.status_isClear is True:
-            self.api_requester.reply_ready.connect(self.update_fields)
-            self.api_requester.api_get_requests()
-        else:
-            pass
-
-        # method end
+        self.api_requester.send_request()
         return
 
     def next_page(self):
@@ -918,11 +912,8 @@ class Isogeo:
             # URL BUILDING FUNCTION CALLED.
             self.api_requester.currentUrl = self.api_requester.build_request_url(params)
             # Sending the request
-            if self.api_requester.status_isClear is True:
-                self.api_requester.reply_ready.connect(self.update_fields)
-                self.api_requester.api_get_requests()
+            self.api_requester.send_request()
                 
-
     def previous_page(self):
         """Add the _offset parameter to the url to display previous page.
 
@@ -950,11 +941,8 @@ class Isogeo:
             # URL BUILDING FUNCTION CALLED.
             self.api_requester.currentUrl = self.api_requester.build_request_url(params)
             # Sending the request
-            if self.api_requester.status_isClear is True:
-                self.api_requester.reply_ready.connect(self.update_fields)
-                self.api_requester.api_get_requests()
+            self.api_requester.send_request()
                       
-
     def set_widget_status(self):
         """Set a few variable and send the request to Isogeo API."""
         selected_search = self.dockwidget.cbb_quicksearch_use.currentText()
@@ -1004,13 +992,7 @@ class Isogeo:
                     canvas.refresh()
             # load request
             self.api_requester.currentUrl = search_params.get('url')
-            if self.api_requester.status_isClear is True:
-                self.api_requester.reply_ready.connect(self.update_fields)
-                self.api_requester.api_get_requests()
-                    
-            else:
-                logger.info("A request to the API is already running."
-                            "Please wait and try again later.")
+            self.api_requester.send_request()
         else:
             if self.savedSearch == "first":
                 logger.debug("First search. Launch '_default' search.")
@@ -1019,8 +1001,7 @@ class Isogeo:
                 search_params = saved_searches.get('_default')
 
                 self.api_requester.currentUrl = search_params.get('url')
-                self.api_requester.reply_ready.connect(self.update_fields)
-                self.api_requester.api_get_requests()
+                self.api_requester.send_request()
 
             else :
                 logger.debug("No quicksearch selected.")
@@ -1154,77 +1135,15 @@ class Isogeo:
         logger.debug("Full metatada sheet asked. Building the url.")
         self.api_requester.currentUrl = "{}/resources/{}{}".format(self.api_requester.api_url_base, md_id,
             "?_include=conditions,contacts,coordinate-system,events,feature-attributes,limitations,keywords,specifications")
+        self.api_requester.send_request("details")
 
-        self.showDetails = True
-        if self.api_requester.status_isClear is True:
-            self.showDetails = False
-            self.api_requester.reply_ready.connect(self.show_md)
-            self.api_requester.api_get_requests()
-            
-        else:
-            pass
-    
-    def show_md(self):
-        self.api_requester.reply_ready.disconnect()
-        self.md_display.show_complete_md(md = self.api_requester.reply_content)
-
-    # -- SETTINGS - Shares ----------------------------------------------------
-    def ask_shares_info(self, index):
-        """TODO : Only if not already done before."""
-        if index == 0:
-            pass
-        elif index == 1 and self.api_requester.status_isClear is True:
-            if self.dockwidget.txt_shares.toPlainText() == "":
-                self.settingsRequest = True
-                self.api_requester.oldUrl = self.api_requester.currentUrl
-                self.api_requester.currentUrl = "{}/shares".format(self.api_requester.api_url_base)
-                self.api_requester.reply_ready.connect(self.write_shares_info)
-                self.api_requester.api_get_requests()
-                
-
-            else:
-                pass
-        else:
-            pass
-        QgsMessageLog.logMessage("Shares information retrieved in settings tab.",
-                                 "Isogeo")
-        # method end
-        return
-
-    def write_shares_info(self):
+    def write_shares_info(self, text:str):
         """Write informations about the shares in the Settings pannel.
         See: #87
 
-        :param content dict: share informations from Isogeo API
+        :param text str: share informations from Isogeo API
         """
-        content = self.api_requester.reply_content
-        self.api_requester.reply_ready.disconnect()
-        self.api_requester.currentUrl = self.api_requester.oldUrl
-        text = u"<html>"  # opening html content
-        # Isogeo application authenticated in the plugin
-        app = content[0].get("applications")[0]
-        text += self.tr(u"<p>This plugin is authenticated as "
-                        u"<a href='{}'>{}</a> and ").format(app.get("url", "https://isogeo.gitbooks.io/app-plugin-qgis/content"),
-                            app.get("name", "Isogeo plugin for QGIS"))
-        # shares feeding the application
-        if len(content) == 1:
-            text += self.tr(u" powered by 1 share:</p></br>")
-        else:
-            text += self.tr(u" powered by {0} shares:</p></br>").format(len(content))
-        # shares details
-        for share in content:
-            # share variables
-            creator_name = share.get("_creator").get("contact").get("name")
-            creator_email = share.get("_creator").get("contact").get("email")
-            creator_id = share.get("_creator").get("_tag")[6:]
-            share_url = "https://app.isogeo.com/groups/{}/admin/shares/{}".format(creator_id, share.get("_id"))
-            # formatting text
-            text += u"<p><a href='{}'><b>{}</b></a></p>".format(share_url,
-                            share.get("name"))
-            text += self.tr(u"<p>Updated: {}</p>").format(plg_tools.handle_date(share.get("_modified")))
-            text += self.tr(u"<p>Contact: {} - {}</p>").format(creator_name, creator_email)
-            text += u"<p><hr></p>"
-        text += u"</html>"
+        logger.debug("Displaying application properties.")
         self.dockwidget.txt_shares.setText(text)
         # method ending
         return
@@ -1286,6 +1205,7 @@ class Isogeo:
         
         # -- Quicksearches ----------------------------------------------------
         self.quicksearch = QuickSearchManager(self)
+        self.quicksearch.request_url_builder = self.api_requester.build_request_url
         # select and use
         self.dockwidget.cbb_quicksearch_use.activated.connect(self.set_widget_status)
 
@@ -1324,7 +1244,6 @@ class Isogeo:
 
         """ ------ CUSTOM CONNECTIONS ------------------------------------- """
         # get shares only if user switch on tabs
-        self.dockwidget.tabWidget.currentChanged.connect(self.ask_shares_info)
         # catch QGIS log messages - see: https://gis.stackexchange.com/a/223965/19817
         QgsApplication.messageLog().messageReceived.connect(plg_tools.error_catcher)
 

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,4 +1,4 @@
-from .api import Authenticator, ApiRequester
+from .api import Authenticator, ApiRequester, SharesParser
 from .metadata_display import MetadataDisplayer
 from .results import ResultsManager, CacheManager 
 from .tools import IsogeoPlgTools

--- a/modules/api/__init__.py
+++ b/modules/api/__init__.py
@@ -1,2 +1,3 @@
 from .auth import Authenticator
 from .request import ApiRequester
+from .shares import SharesParser

--- a/modules/api/request.py
+++ b/modules/api/request.py
@@ -12,8 +12,8 @@ from qgis.core import QgsNetworkAccessManager, QgsMessageLog
 from qgis.utils import iface
 
 # PyQT
-from qgis.PyQt.QtCore import QByteArray, QUrl, QObject, pyqtSignal
-from qgis.PyQt.QtNetwork import QNetworkRequest
+from qgis.PyQt.QtCore import QByteArray, QUrl, QObject, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkAccessManager, QNetworkReply
 
 # ############################################################################
 # ########## Globals ###############
@@ -26,17 +26,23 @@ msgBar = iface.messageBar()
 # ########## Classes ###############
 # ##################################
 
-class ApiRequester(QObject):
+# class ApiRequester(QObject):
+class ApiRequester(QgsNetworkAccessManager):
     """Basic class to manage direct interactions with Isogeo's API :
         - Authentication request for token
+        - Request about application's shares
         - Request about ressources
         - Building request URLs
     """
 
-    reply_ready = pyqtSignal()
-    token_received = pyqtSignal(str)
+    token_sig = pyqtSignal(str)
+    search_sig = pyqtSignal(dict)
+    details_sig = pyqtSignal(dict)
+    shares_sig = pyqtSignal(list)
 
     def __init__(self):
+        # inheritance
+        super().__init__()
 
         self.tr = object
 
@@ -56,14 +62,8 @@ class ApiRequester(QObject):
         self.status_isClear = True
         # make request
         self.token = str
-        self.currentURL = str
-        self.oldUrl = str
-        self.qgs_nam = QgsNetworkAccessManager.instance()
-        # store api reply 
-        self.reply_content = {}
-
-        # inheritance
-        super().__init__()
+        self.currentUrl = str
+        self.finished.connect(self.handle_reply)
 
     def setup_api_params(self, dict_params: dict):
         """Store API parameters of the application (URLs and credentials)
@@ -79,253 +79,259 @@ class ApiRequester(QObject):
         self.api_url_auth = dict_params.get("url_auth", "")
         self.api_url_token = dict_params.get("url_token", "")
         self.api_url_redirect = dict_params.get("url_redirect", "")
+        # sending an authentication request once API parameters are storer
+        self.send_request("token")
+        # self.auth_post_get_token()
 
-        self.api_auth_post_get_token()
+    def create_request(self, request_type:str):
+        """Creates a QNetworkRequest() with appropriate headers and URL
+        according to the 'request_type' parameter.
+        
+        :param str request_type: type of request to create. Options:
+            - 'token'
+            - 'search'
+            - 'details'
+            - 'shares'
 
-    def api_auth_post_get_token(self):
-        """Ask a token from Isogeo API authentification page.
-        This send a POST request to Isogeo API with the user id and secret in
-        its header. The API should return an access token.
+        :returns: the QNetworkRequest to send to the Isogeo's API
 
-        That's the api_auth_handle_token method which get the API's response. See below.
+        :rtype: QNetworkRequest
         """
-        logger.debug("Use loaded credentials to authenticate the plugin.")
-
-        # creating credentials header
+        logger.debug("Creating a '{}' request".format(request_type))
+        # creating headers (same steps wathever request_type value)
         header_value = QByteArray()
-        header_value.append("Basic ")
-        header_value.append(base64.b64encode("{}:{}".format(self.app_id, self.app_secret).encode()))
-
         header_name = QByteArray()
         header_name.append("Authorization")
-        
-        # creating Content-Type header
-        ct_header_value = QByteArray()
-        ct_header_value.append("application/json")
-
-        #creating data
-        databyte = QByteArray()
-        databyte.append(urlencode({"grant_type": "client_credentials"}))
-
-        # build URL request
-        url = QUrl(self.api_url_token)
-        request = QNetworkRequest(url)
-        
-        # setting headers
+        # for token request
+        if request_type == "token":
+            # filling request header with credentials
+            header_value.append("Basic ")
+            header_value.append(base64.b64encode("{}:{}".format(self.app_id, self.app_secret).encode()))
+            # creating the QNetworkRequest from oAuth2 authentication URL     
+            request = QNetworkRequest(QUrl(self.api_url_token))
+            # creating and setting the 'Content-type header' 
+            ct_header_value = QByteArray()
+            ct_header_value.append("application/json")
+            request.setHeader(request.ContentTypeHeader, ct_header_value)
+        # for other request_type, setting appropriate url
+        else : 
+            if request_type == "shares":
+                url = QUrl("{}/shares".format(self.api_url_base))
+            elif request_type == "search" or request_type == "details" :
+                url = QUrl(self.currentUrl)
+            else :
+                logger.debug("Unkown request type asked : {}".format(request_type))
+                raise ValueError
+            # filling request header with token
+            header_value.append(self.token)
+            request = QNetworkRequest(url)
+        # creating QNetworkRequest from appropriate url
         request.setRawHeader(header_name, header_value)
-        request.setHeader(request.ContentTypeHeader, ct_header_value)
+        return request
+
+    def send_request(self, request_type: str = "search"):
+        """ Sends a request to the Isogeo's API using QNetworkRequestManager.
+        That's the handle_reply method which get the API's response. See below.
         
-        if self.status_isClear is True:
-            self.status_isClear = False
-            logger.debug("Token POST request sent to {}".format(request.url()))
-
-            token_reply = self.qgs_nam.post(request, databyte)
-            token_reply.finished.connect(partial(self.api_auth_handle_token, answer = token_reply))
-
-        else:
-            logger.debug("Network in use. Try again later.")
-    
-    def api_auth_handle_token(self, answer: object):
-        """Handle the API answer when asked for a token.
-        This handles the API answer. The token_received signal is emitted
-        providing data (str) whose value dependes on the content of the 
-        answer. Options:
-            - 'noInternet' 
-            - 'tokenOk'
-            - 'credIssue'
-            - 'authIssue'
-        The Isogeo().token_result method is connected to this signal and launches
-        different actions depending on tha data provided's value once the API's
-        response is received and handled.
-
-        :param QNetworkReply answer: Isogeo ID API response
+        :param str request_type: type of request to send. Options:
+            - 'token'
+            - 'search'
+            - 'details'
+            - 'shares'
         """
-        logger.debug("Asked a token and got a reply from the API: {}".format(answer))
-        bytarray = answer.readAll()
+        logger.debug("-------------- Sending a '{}' request --------------".format(request_type))
+        # creating the QNetworkRequest appropriate to the request_type
+        request = self.create_request(request_type)
+        logger.debug("to : {}".format(request.url().toString()))
+        # post request for 'token' request 
+        if request_type == "token":
+            data = QByteArray()
+            data.append(urlencode({"grant_type": "client_credentials"}))
+            reply = self.post(request, data)
+        # get request for other
+        else :
+            reply = self.get(request)
+        return
+
+    def handle_reply(self, reply: QNetworkReply):
+        """Slot to QNetworkAccesManager.finished signal who handles the API's response to any type 
+        of request : 'token', 'search', 'shares' or 'details'.
+
+        The request's type is identicated from the url of the request from which the answer comes. 
+        Depending on the reply's content validity and the request's type, an appropriated signal 
+        is emitted with different data's value.
+
+        - For token requests : the token_sig signal is emitted wathever the replys's content but the emitted 
+        str's value depend on this content. A single slot is connected to this signal and acts 
+        according to value of the string recieved (see isogeo.py : Isogeo.token_slot).
+        - For other requests : for each type of request there is a corresponding signal but the reply's 
+        parsed content is emitted wathever the request's type. Each signal is connected to an appropriate 
+        slot (see isogeo.py).
+
+        :param QNetworkReply reply: Isogeo API response
+        """
+
+        # retrieving API reply content
+        bytarray = reply.readAll()
         content = bytarray.data().decode("utf8")
-        # check API response structure
-        try:
-            parsed_content = json.loads(content)
-        except ValueError as e:
-            if "No JSON object could be decoded" in str(e):
-                logger.error("Internet connection failed")
-                self.token_received.emit("noInternet")
-
-            else:
-                pass
-            return
-
-        self.status_isClear = True
-        # if structure is OK, parse and check response status
-        if 'access_token' in parsed_content:
-            QgsMessageLog.logMessage("Authentication succeeded", "Isogeo")
-            logger.debug("Access token retrieved.")
-            self.token = "Bearer " + parsed_content.get('access_token')
-            self.token_received.emit("tokenOk")
-
-        # TO DO : Distinguer plusieurs cas d'erreur
-        elif 'error' in parsed_content:
-            logger.error("The API reply is an error: {}. ID and SECRET must be "
-                         "invalid. Asking for them again."
-                         .format(parsed_content.get('error')))
-            self.token_received.emit("credIssue")
-
-        else:
-            logger.debug("The API reply has an unexpected form: {}"
-                          .format(parsed_content))
-            self.token_received.emit("authIssue")
+        # if reply's content is valid
+        if reply.error() == 0 and content != "":
+            try:
+                parsed_content = json.loads(content)
+            except ValueError as e:
+                if "No JSON object could be decoded" in str(e):
+                    logger.error("Internet connection failed")
+                else:
+                    pass
+                return
         
-    def api_get_requests(self):
-        """Send a content url to the Isogeo API.
-        This takes the currentUrl class attribute and send a request to this url,
-        using the token class attribute. 
-        
-        That's the api_requests_handle_reply method which get the API's response. See below.
-        """
-        logger.debug("Send a request to the 'currentURL' set: {}."
-                     .format(self.currentUrl))
-        
-        # creating credentials header
-        header_value = QByteArray()
-        header_value.append(self.token)
-        header_name = QByteArray()
-        header_name.append("Authorization")
-        
-        myurl = QUrl(self.currentUrl)
-        request = QNetworkRequest(myurl)
-        request.setRawHeader(header_name, header_value)
-        if self.status_isClear is True:
-            self.status_isClear = False
-            api_reply = self.qgs_nam.get(request)
-            api_reply.finished.connect(partial(self.api_requests_handle_reply, answer=api_reply))
-        else:
-            pass
-
-    def api_requests_handle_reply(self, answer: object):
-        """Handle the different possible Isogeo API answer.
-        This is called when the answer from the API is finished. 
-            -If no error occured and the API's response is not empty, 
-            the reply_ready signal is emitted. The Isogeo class' method 
-            connected to this signal depends on the context in which the 
-            api_get_requests method was called. 
-            - If API's response is empty, an error message is displayed to 
-            the user. 
-            - In other cases, api_auth_post_get_token() method is called.
-
-        :param QNetworkReply answer: Isogeo API search response
-        """
-        logger.info("Request sent to API and reply received.")
-        bytarray = answer.readAll()
-        content = bytarray.data().decode("utf8")
-        if answer.error() == 0 and content != "":
-            logger.debug("Reply is a result json.")
-            self.loopCount = 0
-            self.status_isClear = True
-
-            parsed_content = json.loads(content)
-            self.reply_content = parsed_content
+            url = reply.url().toString()
+            # for token request, one signal is emitted with different data's value
+            # depending on the reply content
+            if "token" in url:
+                logger.debug("Handling reply to a 'token' request")
+                logger.debug("(from : {}).".format(url))
+                if 'access_token' in parsed_content:
+                    QgsMessageLog.logMessage("Authentication succeeded", "Isogeo")
+                    logger.debug("Access token retrieved.")
+                    # storing token
+                    self.token = "Bearer " + parsed_content.get('access_token')
+                    self.token_sig.emit("tokenOK")
+                elif 'error' in parsed_content:
+                    logger.error("The API reply is an error: {}. ID and SECRET must be "
+                                "invalid. Asking for them again."
+                                .format(parsed_content.get('error')))
+                    self.token_sig.emit("credIssue")
+                else:
+                    logger.debug("The API reply has an unexpected form: {}."
+                                .format(parsed_content))
+                    self.token_sig.emit("authIssue")
+            # for other types of request, a different signal is emitted depending
+            # on the type of request but the value of emitted data is always the 
+            # reply's content
+            else :
+                self.loopCount = 0
+                if "shares" in url:
+                    logger.debug("Handling reply to a 'shares' request")
+                    logger.debug("(from : {}).".format(url))
+                    self.shares_sig.emit(parsed_content)
+                elif "resources/search?" in url:
+                    logger.debug("Handling reply to a 'search' request")
+                    logger.debug("(from : {}).".format(url))
+                    self.search_sig.emit(parsed_content)
+                elif "resources/" in reply.url().toString():
+                    logger.debug("Handling reply to a 'details' request")
+                    logger.debug("(from : {}).".format(url))
+                    self.details_sig.emit(parsed_content)
+                else :
+                    logger.debug("Unkown reply type")
+                    return
             del parsed_content
-            self.reply_ready.emit()
-                    
-        elif answer.error() == 204:
+        
+        # if replys's content is invalid
+        elif reply.error() == 204:
             logger.debug("Token expired. Renewing it.")
             self.loopCount = 0
-            self.status_isClear = True
-            self.api_auth_post_get_token()
+            self.send_request("token")
+
         elif content == "":
             logger.error("Empty reply. Weither no catalog is shared with the "
                          "plugin, or there is a problem (2 requests sent "
                          "together)")
             if self.loopCount < 3:
                 self.loopCount += 1
-                answer.abort()
-                del answer
-                self.status_isClear = True
-                self.api_auth_post_get_token()
+                reply.abort()
+                # self.status_isClear = True
+                self.send_request("token")
             else:
-                self.status_isClear = True
+                # self.status_isClear = True
                 msgBar.pushMessage(
                     self.tr("The script is looping. Make sure you shared a "
                             "catalog with the plugin. If so, please report "
                             "this on the bug tracker."))
-        else:
-            self.status_isClear = True
+                return
+        else :
+            logger.warning("Unknown error : {}".format(str(reply.error())))
+            # self.status_isClear = True
             QMessageBox.information(self.iface.mainWindow(),
                                     self.tr("Error"),
                                     self.tr("You are facing an unknown error. "
                                             "Code: ") +
                                     str(answer.error()) +
                                     "\nPlease report it on the bug tracker.")
-        # method end
         return
 
     def build_request_url(self, params: dict):
-            """Build the request url according to the user selection. These URLs 
-            are used by api_get_requests.
-            
-            :param dict params: a dictionnary provided by Isogeo().get_params
-            method
-            """
-            # Base url for a request to Isogeo API
-            url = "{}/resources/search?".format(self.api_url_base)
-            # Build the url according to the params
-            if params.get("text") != "":
-                filters = params.get("text") + " "
-            else:
-                filters = ""
-            # Keywords
-            for keyword in params.get("keys"):
-                filters += keyword + " "
-            # Owner
-            if params.get("owner") is not None:
-                filters += params.get("owner") + " "
-            # SRS
-            if params.get("srs") is not None:
-                filters += params.get("srs") + " "
-            # INSPIRE keywords
-            if params.get("inspire") is not None:
-                filters += params.get("inspire") + " "
-            # Format
-            if params.get("format") is not None:
-                filters += params.get("format") + " "
-            # Data type
-            if params.get("datatype") is not None:
-                filters += params.get("datatype") + " "
-            # Contact
-            if params.get("contact") is not None:
-                filters += params.get("contact") + " "
-            # License
-            if params.get("license") is not None:
-                filters += params.get("license") + " "
-            # Formating the filters
-            if filters != "":
-                filters = "q=" + filters[:-1]
-            # Geographical filter
-            if params.get("geofilter") is not None:
-                if params.get("coord") is not False:
-                    filters += "&box={0}&rel={1}".format(params.get("coord"),
-                                                        params.get("operation"))
-                else:
-                    pass
+        """Builds the request url according to the user selection. These URLs 
+        are used by create_request.
+        
+        :param dict params: a dictionnary provided by Isogeo().get_params
+        method
+
+        :returns: the URL to send to the Isogeo's API for a search request.
+
+        :rtype: str
+        """
+        # Base url for a request to Isogeo API
+        url = "{}/resources/search?".format(self.api_url_base)
+        # Build the url according to the params
+        if params.get("text") != "":
+            filters = params.get("text") + " "
+        else:
+            filters = ""
+        # Keywords
+        for keyword in params.get("keys"):
+            filters += keyword + " "
+        # Owner
+        if params.get("owner") is not None:
+            filters += params.get("owner") + " "
+        # SRS
+        if params.get("srs") is not None:
+            filters += params.get("srs") + " "
+        # INSPIRE keywords
+        if params.get("inspire") is not None:
+            filters += params.get("inspire") + " "
+        # Format
+        if params.get("format") is not None:
+            filters += params.get("format") + " "
+        # Data type
+        if params.get("datatype") is not None:
+            filters += params.get("datatype") + " "
+        # Contact
+        if params.get("contact") is not None:
+            filters += params.get("contact") + " "
+        # License
+        if params.get("license") is not None:
+            filters += params.get("license") + " "
+        # Formating the filters
+        if filters != "":
+            filters = "q=" + filters[:-1]
+        # Geographical filter
+        if params.get("geofilter") is not None:
+            if params.get("coord") is not False:
+                filters += "&box={0}&rel={1}".format(params.get("coord"),
+                                                    params.get("operation"))
             else:
                 pass
-            # Sorting order and direction
-            if params.get("show"):
-                filters += "&ob={0}&od={1}".format(params.get("ob"),
-                                                params.get("od"))
-                filters += "&_include=serviceLayers,layers"
-                limit = 10
-            else:
-                limit = 0
-            # Limit and offset
-            offset = (params.get("page") - 1) * 10
-            filters += "&_limit={0}&_offset={1}".format(limit, offset)
-            # Language
-            filters += "&_lang={0}".format(params.get("lang"))
-            # BUILDING FINAL URL
-            url += filters
-            # method ending
-            return url        
+        else:
+            pass
+        # Sorting order and direction
+        if params.get("show"):
+            filters += "&ob={0}&od={1}".format(params.get("ob"),
+                                            params.get("od"))
+            filters += "&_include=serviceLayers,layers"
+            limit = 10
+        else:
+            limit = 0
+        # Limit and offset
+        offset = (params.get("page") - 1) * 10
+        filters += "&_limit={0}&_offset={1}".format(limit, offset)
+        # Language
+        filters += "&_lang={0}".format(params.get("lang"))
+        # BUILDING FINAL URL
+        url += filters
+        # method ending
+        return url        
 
 # #############################################################################
 # ##### Stand alone program ########

--- a/modules/api/shares.py
+++ b/modules/api/shares.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+# Standard library
+import logging
+
+# PyQGIS
+from qgis.core import QgsNetworkAccessManager
+
+# PyQT
+from qgis.PyQt.QtCore import pyqtSignal, QThread, QObject, pyqtSlot
+
+# Plugin modules
+from ..tools import IsogeoPlgTools
+
+# ############################################################################
+# ########## Globals ###############
+# ##################################
+
+logger = logging.getLogger("IsogeoQgisPlugin")
+plg_tools = IsogeoPlgTools()
+# ############################################################################
+# ########## Classes ###############
+# ##################################
+
+
+class SharesParser(QObject):
+    """Build the string informing the user about the shares feeding his plugin 
+    from the Isogeo API's response to a share request.
+    """
+    shares_ready = pyqtSignal(str)
+
+    def __init__(self):
+        QObject.__init__(self)
+        self.tr = object
+
+    @pyqtSlot(list)
+    def send_share_info(self, result: list):
+        """Slot connected to ApiRequester.shares_sig signal emitted when a response 
+        to a share request has been received from the Isogeo's API, validated and parsed.
+        'result' parameter correspond to the content of shares request's reply passed 
+        by the ApiRequester.handle_reply method (see modules/api/request.py). 
+        Once the string building from 'result' is done, the shares_ready signal is emitted 
+        passing this string to a connected slot : Isogeo.write_shares_info (see isogeo.py).
+        
+        :param list result: list of shares feeding the application
+        """
+        logger.debug("Application properties provided by the Isogeo API.")
+        content = result
+
+        text = u"<html>"  # opening html content
+        # Isogeo application authenticated in the plugin
+        app = content[0].get("applications")[0]
+        text += self.tr(u"<p>This plugin is authenticated as "
+                        u"<a href='{}'>{}</a> and ").format(app.get("url", "https://isogeo.gitbooks.io/app-plugin-qgis/content"),
+                            app.get("name", "Isogeo plugin for QGIS"))
+        # shares feeding the application
+        if len(content) == 1:
+            text += self.tr(u" powered by 1 share:</p></br>")
+        else:
+            text += self.tr(u" powered by {} shares:</p></br>").format(len(content))
+        # shares details
+        for share in content:
+            # share variables
+            creator_name = share.get("_creator").get("contact").get("name")
+            creator_email = share.get("_creator").get("contact").get("email")
+            creator_id = share.get("_creator").get("_tag")[6:]
+            share_url = "https://app.isogeo.com/groups/{}/admin/shares/{}".format(creator_id, share.get("_id"))
+            # formatting text
+            text += u"<p><a href='{}'><b>{}</b></a></p>".format(share_url,
+                            share.get("name"))
+            text += self.tr(u"<p>Updated: {}</p>").format(plg_tools.handle_date(share.get("_modified")))
+            text += self.tr(u"<p>Contact: {} - {}</p>").format(creator_name, creator_email)
+            text += u"<p><hr></p>"
+        text += u"</html>"
+        self.shares_ready.emit(text)
+
+# #############################################################################
+# ##### Stand alone program ########
+# ##################################
+if __name__ == '__main__':
+    """Standalone execution."""

--- a/modules/api/shares.py
+++ b/modules/api/shares.py
@@ -34,7 +34,7 @@ class SharesParser(QObject):
         self.tr = object
 
     @pyqtSlot(list)
-    def send_share_info(self, result: list):
+    def send_share_info(self, shares: list):
         """Slot connected to ApiRequester.shares_sig signal emitted when a response 
         to a share request has been received from the Isogeo's API, validated and parsed.
         'result' parameter correspond to the content of shares request's reply passed 
@@ -45,7 +45,7 @@ class SharesParser(QObject):
         :param list result: list of shares feeding the application
         """
         logger.debug("Application properties provided by the Isogeo API.")
-        content = result
+        content = shares
 
         text = u"<html>"  # opening html content
         # Isogeo application authenticated in the plugin

--- a/modules/layer/add_layer.py
+++ b/modules/layer/add_layer.py
@@ -367,8 +367,7 @@ class LayerAdder():
             # check if GetMap operation is available
             if not hasattr(wms, "getmap") or "GetMap" not in [op.name for op in wms.operations]:
                 self.cached_wms["GetMap"] = 1
-                return 0, "Required GetMap operation not available in: "\
-                          + wms_url_getcap
+                return 0, "Required GetMap operation not available in: "+ wms_url_getcap
             else:
                 self.cached_wms["GetMap"] = 0
                 pass
@@ -403,9 +402,7 @@ class LayerAdder():
             if srs_map in wms_lyr.crsOptions:
                 logger.debug("It's a SRS match! With map canvas: " + srs_map)
                 srs = srs_map
-            elif srs_qgs_new in wms_lyr.crsOptions\
-                 and srs_qgs_otf_on == "false"\
-                 and srs_qgs_otf_auto == "false":
+            elif srs_qgs_new in wms_lyr.crsOptions and srs_qgs_otf_on == "false" and srs_qgs_otf_auto == "false":
                 logger.debug("It's a SRS match! With default new project: " + srs_qgs_new)
                 srs = srs_qgs_new
             elif srs_lyr_crs in wms_lyr.crsOptions and srs_lyr_new == "useGlobal":
@@ -431,7 +428,7 @@ class LayerAdder():
                 layer_format = formats_image[0]
 
             # Style definition
-            lyr_style = wms_lyr.styles.keys()[0]
+            lyr_style = list(wms_lyr.styles.keys())[0]
 
             # GetMap URL
             wms_lyr_url = wms.getOperationByName('GetMap').methods
@@ -744,8 +741,7 @@ class LayerAdder():
                             logger.debug("WMS layer added: {0}".format(url))
                         else:
                             error_msg = layer.error().message()
-                            logger.warning("Invalid service: {0}. QGIS says: {}"
-                                           .format(url, error_msg.encode("latin1")))
+                            logger.warning("Invalid service: {0}. QGIS says: {1}".format(url, error_msg.encode("latin1")))
                     else:
                         QMessageBox.information(
                             iface.mainWindow(),

--- a/modules/metadata_display.py
+++ b/modules/metadata_display.py
@@ -63,7 +63,7 @@ class MetadataDisplayer(object):
 
         self.complete_md.btn_md_edit.pressed.connect(lambda: plg_tools.open_webpage(link=self.url_edition))
 
-    def show_complete_md(self, md):
+    def show_complete_md(self, md:dict):
         """Open the pop up window that shows the metadata sheet details.
         
         :param md dict: Isogeo metadata dict

--- a/modules/metadata_display.py
+++ b/modules/metadata_display.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from qgis.core import (QgsProject, QgsMessageLog, QgsVectorLayer, QgsPointXY, 
                         QgsRectangle, QgsFeature, QgsGeometry, QgsRasterLayer, QgsRenderContext)
 
-
 # PyQT
 from qgis.PyQt.QtCore import QSettings, Qt
 from qgis.PyQt.QtGui import QColor
@@ -22,6 +21,9 @@ from .isogeo_pysdk import IsogeoTranslator
 # Plugin modules
 from .api import Authenticator
 from .tools import IsogeoPlgTools
+
+# UI module 
+from ..ui.metadata.dlg_md_details import IsogeoMdDetails
 
 # ############################################################################
 # ########## Globals ###############
@@ -52,9 +54,9 @@ class MetadataDisplayer(object):
     """Manage metadata displaying in QGIS UI."""
     url_edition = "https://app.isogeo.com"
 
-    def __init__(self, ui_md_details):
+    def __init__(self):
         """Class constructor."""
-        self.complete_md = ui_md_details
+        self.complete_md = IsogeoMdDetails()
         self.complete_md.stackedWidget.setCurrentIndex(0)
 
         # some basic settings

--- a/modules/quick_search.py
+++ b/modules/quick_search.py
@@ -47,7 +47,7 @@ class QuickSearchManager():
         self.lang = isogeo_plg.lang
 
         # Getting wath the class need from ApiRequester to build search URL
-        self.requester = object
+        self.request_url_builder = object
 
         # Setting ui elements from plugin dockwidget
         self.btn_save = self.dockwidget.btn_quicksearch_save
@@ -90,7 +90,7 @@ class QuickSearchManager():
         # Info for _lang parameter
         params['lang'] = self.lang
         # building request url
-        params['url'] = self.requester.build_request_url(params)
+        params['url'] = self.request_url_builder(params)
 
         for i in range(len(params.get('keys'))):
             params['keyword_{0}'.format(i)] = params.get('keys')[i]

--- a/test/test_api_requester.py
+++ b/test/test_api_requester.py
@@ -18,16 +18,13 @@ class TestApiRequester(unittest.TestCase):
     def test_setup_api_params(self):
         pass
 
-    def test_api_auth_post_get_token(self):
+    def test_create_request(self):
         pass
 
-    def test_api_auth_handle_token(self):
+    def test_send_request(self):
         pass
 
-    def test_api_get_requests(self):
-        pass
-
-    def test_api_requests_handle_reply(self):
+    def test_handle_request(self):
         pass
     
     def test_build_request_url(self):


### PR DESCRIPTION
# 1 new module

## Context

Improve plugin operation and make corrections (#180 ).

## Achievments

### `modules/api/shares.py`

* *Issue :* #177, #215 

* **Class name :** **SharesParser**

* **Purpose :** This class only handles the parsing of informations about the shares that feed the plugin. Its *send_shares()* method takes as argument the content of the API's response to a shares request. This content is processed to build a string using XML tags to show the user basic informations about his application. This method therefore performs many of the tasks previously performed by the *write_shares_info()* method of the main class **Isogeo**. The only role of *write_shares_info* is now to fill a widget of the UI with the string built by **SharesParser**.

* **Improvement :** The formatting of information about sharing has been removed from the main class **Isogeo**. The shares request is sent only once, during authentication with the Isogeo API. The asynchronous API of **QgsNetworkAccessManager** is used to send this shares request at the same time as the first search request. This makes the plugin initialization faster.

## Code organization

This pull request concerns the module `modules/api/shares.py` but the modifications made to the module `modules/api/requester.py` constitute the main contribution of this iteration.
The operation of the class **ApiRequester** of the module `modules/api/requester.py` has been modified to allow two requests to be sent to the Isogeo API simultaneously using the asynchronous API of **QgsNetworkAccessManager**. 
**2 main changes between #213 and #216:**
* **ApiRequester** inherits from **QgsNetworkAccessManager**
* A more sophisticated system of signals and slots to link **ApiRequester** with the main class **Isogeo**,  **SharesParser** and **MetadataDisplayer** (`module/metadata_dispaly.py`).

### After #213 
**ApiRequester** used **QgsNetworkAccessManager.instance()** as an attribute so it was using the same instance of **QgsNetworkAccessManager** as the one used by QGIS and worked that way: 

* with **4 methods** to manage requesting to Isogeo's API:
  * *api_auth_post_get_token()* : to create and send authentication request 
  * *api_auth_handle_token(answer: object)* : to handle Isogeo's API reply to authentication request
  * *api_get_requests()* : to create and send search request, shares request or details request
  *  *api_requests_handle_reply(answer: object)* : to handle Isogeo's API reply search request, shares request or details request

* by emitting **2 signals**:
  * *token_received[str]*: Emitted by *api_auth_handle_token(answer: object)* once Isogeo's API's reply to authentication request is received and parsed. 
  **A string is passed** to the connected slot (**Isogeo**'s *token_result()* method). Its value depend on answer's content : 'tokenOk', 'credissue', 'noInternet' or 'authIssue'. 
  The connected slot acts differently depending on the value of the string received.
  * *reply_ready[]*: Emitted by *api_requests_handle_reply(answer: object)* once Isogeo's API's reply to other type of request is received, parsed and validated. 
  **The parsed content** of the Isogeo's API reply **is stored** into an **ApiRequester**'s attribute. 
  The connected slot depend on the context in which the *api_get_requests()* method was called : 
    * *Isogeo.update_fiedls()* for a search request
    * *Isogeo.write_shares_info()* for a shares request
    * *Isogeo.show_md()* for a details request

### Since #216
**ApiRequester** inherits from **QgsNetworkAccessManager** and worked that way: 

* with **3 methods** to manage requesting to Isogeo's API:
  * *create_request(request_type:str)* : to create request using **QNetworkRequest** with appropriate headers depending on 'request_type' parameter
  * *send_request(request_type:str)* : to send request returned by *create_request(request_type:str)* using *post()* or *get()* methods inherited from **QgsNetworkAccessManager** depending on 'request_type' parameter
  * *handle_reply(reply:QNetworkReply)* : to handle reply from Isogeo's API to any type of request and emit appropriate signal and passing appropriate data depending on the type of request send by   *send_request(request_type:str)*

* by emitting **4 signals**:
  * *token_sig[str]*: same as after #213 
  * *search_sig[dict]*: Emitted by *handle_reply(reply:QNetworkReply)* once Isogeo's API's reply to search request is received, parsed and validated. 
  **The parsed content** of the Isogeo's API reply is **passed as a dictionnary** to the connected slot: *Isogeo.update_fiedls(result: dict)*.
  * *details_sig[dict]*: Emitted by *handle_reply(reply:QNetworkReply)* once Isogeo's API's reply to details request is received, parsed and validated.
  **The parsed content** of the Isogeo's API reply is **passed as a dictionnary** to the connected slot: *MetadataDisplayer.show_complete_md(md: dict)*.
  * *shares_sig[list]*: Emitted by *handle_reply(reply:QNetworkReply)* once Isogeo's API's reply to shares type of request is received, parsed and validated.
  **The parsed content** of the Isogeo's API reply is **passed as a list** to the connected slot: *SharesParser.send_share_info(shares: list)*.

### Modules' instantiation

The **SharesParser** class is instantiated as an attribute of the main class **Isogeo** during its initialization. 

### Links between the modules

The method *send_shares()* of **SharesParser** is used as a slot connected to the *shares_sig* signal transmitted by **ApiRequester**. 
At the end of the execution of its method *send_shares()*, **SharesParser** emits the signal *shares_ready* to which is connected the method *write_shares_info()* of the main class **Isogeo**.




